### PR TITLE
Fix invalid callback in .write and callbacks invoked synchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Read the current `dat.json`.
 
 [npm-image]: https://img.shields.io/npm/v/dat-json.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/dat-json
-[travis-image]: https://img.shields.io/travis/joehand/dat-json.svg?style=flat-square
-[travis-url]: https://travis-ci.org/joehand/dat-json
+[travis-image]: https://img.shields.io/travis/datproject/dat-json.svg?style=flat-square
+[travis-url]: https://travis-ci.org/datproject/dat-json
 [standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square
 [standard-url]: http://npm.im/standard

--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ module.exports = function (archive, opts) {
     delete: db.delete,
     create: function (data, cb) {
       if (typeof data === 'function') return that.create(null, data)
-      if (!archive.writable) return cb(new Error('Archive not writable'))
+      if (!archive.writable) {
+        return process.nextTick(cb, new Error('Archive not writable'))
+      }
       data = xtend(getdefaults(), data)
       that.write(data, cb)
     }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ module.exports = function (archive, opts) {
       })
     },
     write: function (key, val, cb) {
-      if (!archive.writable) return cb(new Error('Archive not writable'))
+      if (!archive.writable) {
+        return process.nextTick(cb, new Error('Archive not writable'))
+      }
       if (typeof key === 'object') return writeAll(key, val) // assume val = cb
       // TODO: validate things
       if (!fileDb) return db.write(key, val, cb)

--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ module.exports = function (archive, opts) {
   }
 
   function writeAll (data, cb) {
-    if (!archive.writable) return cb(new Error('Archive not writable'))
     var keys = Object.keys(data)
     var pending = keys.length
     keys.map(function (key) {

--- a/index.js
+++ b/index.js
@@ -17,10 +17,11 @@ module.exports = function (archive, opts) {
       })
     },
     write: function (key, val, cb) {
+      if (typeof val === 'function') cb = val
       if (!archive.writable) {
         return process.nextTick(cb, new Error('Archive not writable'))
       }
-      if (typeof key === 'object') return writeAll(key, val) // assume val = cb
+      if (typeof key === 'object') return writeAll(key, cb)
       // TODO: validate things
       if (!fileDb) return db.write(key, val, cb)
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/joehand/dat-json/issues"
   },
   "devDependencies": {
+    "hyperdrive": "^9.12.3",
     "random-access-memory": "^2.4.0",
     "standard": "*",
     "tap-spec": "^4.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,18 @@ test('Write dat.json to archive', function (t) {
   })
 })
 
+test('.create with no writable archive errors', function (t) {
+  var archive = { writable: false }
+  var datjson = datJSON(archive)
+  var async = false
+  datjson.create(function (err) {
+    t.is(err.message, 'Archive not writable', 'should error')
+    t.is(async, true, 'callback is asyncronous')
+    t.end()
+  })
+  async = true
+})
+
 test('Write dat.json to file and archive', function (t) {
   var archive = hyperdrive(ram)
   var file = path.join(__dirname, 'dat.json')

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,18 @@ test('.create with no writable archive errors', function (t) {
   async = true
 })
 
+test('.write with key/value and no writable archive errors', function (t) {
+  var archive = { writable: false }
+  var datjson = datJSON(archive)
+  var async = false
+  datjson.write('key', 'value', function (err) {
+    t.is(err.message, 'Archive not writable', 'should error')
+    t.is(async, true, 'callback is asyncronous')
+    t.end()
+  })
+  async = true
+})
+
 test('Write dat.json to file and archive', function (t) {
   var archive = hyperdrive(ram)
   var file = path.join(__dirname, 'dat.json')

--- a/test/index.js
+++ b/test/index.js
@@ -72,6 +72,18 @@ test('.write with key/value and no writable archive errors', function (t) {
   async = true
 })
 
+test('.write with data object and no writable archive errors', function (t) {
+  var archive = { writable: false }
+  var datjson = datJSON(archive)
+  var async = false
+  datjson.write({specialVal: 'cat'}, function (err) {
+    t.is(err.message, 'Archive not writable', 'should error')
+    t.is(async, true, 'callback is asyncronous')
+    t.end()
+  })
+  async = true
+})
+
 test('Write dat.json to file and archive', function (t) {
   var archive = hyperdrive(ram)
   var file = path.join(__dirname, 'dat.json')


### PR DESCRIPTION
Also added some extra tests for making sure that `cb` isn't called synchronously.

Fixes https://github.com/datproject/dat/issues/928

If you're happy with this, feel free to squash it to reduce noise.